### PR TITLE
Add dynamic loader for meshi API

### DIFF
--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -17,7 +17,10 @@ target_compile_options(meshi INTERFACE -Wno-return-type-c-linkage)
 
 # Optional: Add any dependencies for the interface target
 target_link_libraries(meshi INTERFACE meshi-rs glm)
-add_dependencies(meshi meshi-rs) 
+add_dependencies(meshi meshi-rs)
+target_sources(meshi INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/meshi/bits/meshi_loader.cpp>
+)
 # Optional: If you want to install the library
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
     DESTINATION include

--- a/src/api/meshi/bits/meshi_loader.cpp
+++ b/src/api/meshi/bits/meshi_loader.cpp
@@ -1,0 +1,116 @@
+#include "meshi_loader.hpp"
+
+#include <filesystem>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+namespace meshi {
+namespace detail {
+namespace {
+
+#ifdef _WIN32
+using LibraryHandle = HMODULE;
+inline LibraryHandle open_library(const std::filesystem::path &p) {
+  return LoadLibraryW(p.wstring().c_str());
+}
+inline void *load_symbol(LibraryHandle lib, const char *name) {
+  return reinterpret_cast<void *>(GetProcAddress(lib, name));
+}
+#else
+using LibraryHandle = void *;
+inline LibraryHandle open_library(const std::filesystem::path &p) {
+  return dlopen(p.c_str(), RTLD_LAZY | RTLD_LOCAL);
+}
+inline void *load_symbol(LibraryHandle lib, const char *name) {
+  return dlsym(lib, name);
+}
+#endif
+
+LibraryHandle g_lib{};
+MeshiApi g_api{};
+
+template <typename T>
+bool load_func(const char *name, T &out) {
+  auto sym = load_symbol(g_lib, name);
+  if (!sym)
+    return false;
+  out = reinterpret_cast<T>(sym);
+  return true;
+}
+
+} // namespace
+
+static auto library_name() -> const char * {
+#ifdef _WIN32
+  return "meshi.dll";
+#elif __APPLE__
+  return "libmeshi.dylib";
+#else
+  return "libmeshi.so";
+#endif
+}
+
+auto load_meshi_api(const std::filesystem::path &dir)
+    -> meshi::Result<int, std::string> {
+  auto path = dir / library_name();
+  g_lib = open_library(path);
+  if (!g_lib) {
+    return meshi::make_error<std::string>(
+        std::string("Failed to open library: ") + path.string());
+  }
+
+#define LOAD_SYM(name)                                                          \
+  if (!load_func(#name, g_api.name))                                            \
+    return meshi::make_error<std::string>("Missing symbol: " #name)
+
+  // Engine
+  LOAD_SYM(meshi_make_engine);
+  LOAD_SYM(meshi_make_engine_headless);
+  LOAD_SYM(meshi_destroy_engine);
+  LOAD_SYM(meshi_register_event_callback);
+  LOAD_SYM(meshi_update);
+  LOAD_SYM(meshi_get_graphics_system);
+
+  // Graphics
+  LOAD_SYM(meshi_gfx_create_renderable);
+  LOAD_SYM(meshi_gfx_create_cube);
+  LOAD_SYM(meshi_gfx_create_sphere);
+  LOAD_SYM(meshi_gfx_create_triangle);
+  LOAD_SYM(meshi_gfx_set_renderable_transform);
+  LOAD_SYM(meshi_gfx_create_directional_light);
+  LOAD_SYM(meshi_gfx_set_directional_light_transform);
+  LOAD_SYM(meshi_gfx_set_directional_light_info);
+  LOAD_SYM(meshi_gfx_set_camera);
+  LOAD_SYM(meshi_gfx_set_projection);
+  LOAD_SYM(meshi_gfx_capture_mouse);
+
+  // Physics
+  LOAD_SYM(meshi_get_physics_system);
+  LOAD_SYM(meshi_physx_set_gravity);
+  LOAD_SYM(meshi_physx_create_material);
+  LOAD_SYM(meshi_physx_release_material);
+  LOAD_SYM(meshi_physx_create_rigid_body);
+  LOAD_SYM(meshi_physx_release_rigid_body);
+  LOAD_SYM(meshi_physx_apply_force_to_rigid_body);
+  LOAD_SYM(meshi_physx_set_rigid_body_transform);
+  LOAD_SYM(meshi_physx_get_rigid_body_status);
+  LOAD_SYM(meshi_physx_set_collision_shape);
+  LOAD_SYM(meshi_physx_get_contacts);
+  LOAD_SYM(meshi_physx_collision_shape_sphere);
+  LOAD_SYM(meshi_physx_collision_shape_box);
+
+#undef LOAD_SYM
+
+  return meshi::make_result<int, std::string>(0);
+}
+
+MeshiApi &api() { return g_api; }
+
+} // namespace detail
+} // namespace meshi
+

--- a/src/api/meshi/bits/meshi_loader.hpp
+++ b/src/api/meshi/bits/meshi_loader.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include <meshi/bits/util/result.hpp>
+#include <meshi/bits/meshi.h>
+
+namespace meshi {
+namespace detail {
+
+struct MeshiApi {
+    // Engine
+    decltype(&meshi_make_engine) meshi_make_engine{};
+    decltype(&meshi_make_engine_headless) meshi_make_engine_headless{};
+    decltype(&meshi_destroy_engine) meshi_destroy_engine{};
+    decltype(&meshi_register_event_callback) meshi_register_event_callback{};
+    decltype(&meshi_update) meshi_update{};
+    decltype(&meshi_get_graphics_system) meshi_get_graphics_system{};
+
+    // Graphics
+    decltype(&meshi_gfx_create_renderable) meshi_gfx_create_renderable{};
+    decltype(&meshi_gfx_create_cube) meshi_gfx_create_cube{};
+    decltype(&meshi_gfx_create_sphere) meshi_gfx_create_sphere{};
+    decltype(&meshi_gfx_create_triangle) meshi_gfx_create_triangle{};
+    decltype(&meshi_gfx_set_renderable_transform) meshi_gfx_set_renderable_transform{};
+    decltype(&meshi_gfx_create_directional_light) meshi_gfx_create_directional_light{};
+    decltype(&meshi_gfx_set_directional_light_transform) meshi_gfx_set_directional_light_transform{};
+    decltype(&meshi_gfx_set_directional_light_info) meshi_gfx_set_directional_light_info{};
+    decltype(&meshi_gfx_set_camera) meshi_gfx_set_camera{};
+    decltype(&meshi_gfx_set_projection) meshi_gfx_set_projection{};
+    decltype(&meshi_gfx_capture_mouse) meshi_gfx_capture_mouse{};
+
+    // Physics
+    decltype(&meshi_get_physics_system) meshi_get_physics_system{};
+    decltype(&meshi_physx_set_gravity) meshi_physx_set_gravity{};
+    decltype(&meshi_physx_create_material) meshi_physx_create_material{};
+    decltype(&meshi_physx_release_material) meshi_physx_release_material{};
+    decltype(&meshi_physx_create_rigid_body) meshi_physx_create_rigid_body{};
+    decltype(&meshi_physx_release_rigid_body) meshi_physx_release_rigid_body{};
+    decltype(&meshi_physx_apply_force_to_rigid_body) meshi_physx_apply_force_to_rigid_body{};
+    decltype(&meshi_physx_set_rigid_body_transform) meshi_physx_set_rigid_body_transform{};
+    decltype(&meshi_physx_get_rigid_body_status) meshi_physx_get_rigid_body_status{};
+    decltype(&meshi_physx_set_collision_shape) meshi_physx_set_collision_shape{};
+    decltype(&meshi_physx_get_contacts) meshi_physx_get_contacts{};
+    decltype(&meshi_physx_collision_shape_sphere) meshi_physx_collision_shape_sphere{};
+    decltype(&meshi_physx_collision_shape_box) meshi_physx_collision_shape_box{};
+};
+
+auto load_meshi_api(const std::filesystem::path& lib_path)
+    -> meshi::Result<int, std::string>;
+
+MeshiApi& api();
+
+} // namespace detail
+} // namespace meshi
+


### PR DESCRIPTION
## Summary
- Introduced cross-platform Meshi API loader that uses `dlopen`/`LoadLibrary` and `dlsym`/`GetProcAddress`
- Added `MeshiApi` struct with function pointers for every symbol in `meshi.h` and accessor via `meshi::detail::api()`
- Updated API CMake configuration to compile the new loader

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: fatal error: meshi/bits/meshi_c_api.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688fc91d87b4832a8451b27d29dd7773