### PR TITLE
Load Meshi API dynamically

### DIFF
--- a/src/api/meshi/backend.hpp
+++ b/src/api/meshi/backend.hpp
@@ -5,18 +5,29 @@
 #include <glm/glm.hpp>
 #include <memory>
 #include <meshi/bits/meshi_c_api.h>
+#include <meshi/bits/meshi_loader.hpp>
 #include <meshi/graphics.hpp>
 #include <meshi/physics.hpp>
+#include <mutex>
 #include <string>
 namespace meshi {
 
 class EngineBackend {
 public:
   explicit EngineBackend(const EngineBackendInfo &info) {
-    engine_ = meshi_make_engine(info);
+    static std::once_flag flag;
+    std::call_once(flag, [&]() {
+      auto result = detail::load_meshi_api(info.application_root);
+      if (result.is_err()) {
+        throw std::runtime_error(result.err());
+      }
+    });
 
-    auto raw_phys = meshi_get_physics_system(engine_);
-    auto raw_gfx = meshi_get_graphics_system(engine_);
+    auto &api = detail::api();
+    engine_ = api.meshi_make_engine(info);
+
+    auto raw_phys = api.meshi_get_physics_system(engine_);
+    auto raw_gfx = api.meshi_get_graphics_system(engine_);
     m_phys = PhysicsSystem(raw_phys, raw_gfx);
     m_gfx = GraphicsSystem(raw_gfx);
   }
@@ -25,10 +36,10 @@ public:
 
   void register_event_callback(void *user_data,
                                void (*callback)(meshi::Event &, void *)) {
-    meshi_register_event_callback(engine_, user_data, callback);
+    detail::api().meshi_register_event_callback(engine_, user_data, callback);
   }
 
-  float update() { return meshi_update(engine_); }
+  float update() { return detail::api().meshi_update(engine_); }
 
   inline auto physics() -> PhysicsSystem & { return m_phys; }
 

--- a/src/api/meshi/graphics.hpp
+++ b/src/api/meshi/graphics.hpp
@@ -2,6 +2,7 @@
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>
 #include <meshi/bits/meshi_c_api.h>
+#include <meshi/bits/meshi_loader.hpp>
 
 namespace meshi {
 
@@ -9,28 +10,28 @@ class GraphicsSystem {
 public:
   auto create_renderable(const gfx::RenderableCreateInfo &info)
       -> Handle<gfx::Renderable> {
-    return meshi_gfx_create_renderable(m_gfx, info);
+    return detail::api().meshi_gfx_create_renderable(m_gfx, info);
   }
   
   auto create_directional_light(const gfx::DirectionalLightInfo& info) -> Handle<gfx::DirectionalLight>{
-    return meshi_gfx_create_directional_light(m_gfx, info);
+    return detail::api().meshi_gfx_create_directional_light(m_gfx, info);
   }
 
   void set_transform(Handle<gfx::Renderable> &renderable,
                      glm::mat4 &transform) {
-    meshi_gfx_set_renderable_transform(m_gfx, renderable, (transform));
+    detail::api().meshi_gfx_set_renderable_transform(m_gfx, renderable, (transform));
   }
 
   void set_camera(glm::mat4 &view_matrix) {
-    meshi_gfx_set_camera(m_gfx, (view_matrix));
+    detail::api().meshi_gfx_set_camera(m_gfx, (view_matrix));
   }
 
   void set_projection(glm::mat4 &projection_matrix) {
-    meshi_gfx_set_projection(m_gfx, (projection_matrix));
+    detail::api().meshi_gfx_set_projection(m_gfx, (projection_matrix));
   }
   
   inline auto capture_mouse(bool value) -> void {
-    meshi_gfx_capture_mouse(m_gfx, static_cast<int>(value));
+    detail::api().meshi_gfx_capture_mouse(m_gfx, static_cast<int>(value));
   }
 private:
   friend class EngineBackend;

--- a/src/api/meshi/physics.hpp
+++ b/src/api/meshi/physics.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <glm/glm.hpp>
 #include <meshi/bits/meshi_c_api.h>
+#include <meshi/bits/meshi_loader.hpp>
 
 namespace meshi {
 
@@ -8,29 +9,29 @@ class PhysicsSystem {
 public:
   auto
   create_material(PhysicsMaterialCreateInfo &info) -> Handle<PhysicsMaterial> {
-    return meshi_physx_create_material(m_phys, info);
+    return detail::api().meshi_physx_create_material(m_phys, info);
   }
 
   void release_material(Handle<PhysicsMaterial> &material) {
-    meshi_physx_release_material(m_phys, material);
+    detail::api().meshi_physx_release_material(m_phys, material);
   }
 
   auto create_rigid_body(RigidBodyCreateInfo &info) -> Handle<RigidBody> {
-    return meshi_physx_create_rigid_body(m_phys, m_gfx, info);
+    return detail::api().meshi_physx_create_rigid_body(m_phys, m_gfx, info);
   }
 
   void release_rigid_body(Handle<RigidBody> &rigidBody) {
-    meshi_physx_release_rigid_body(m_phys, rigidBody);
+    detail::api().meshi_physx_release_rigid_body(m_phys, rigidBody);
   }
 
   void apply_force_to_rigid_body(Handle<RigidBody> &rigidBody,
                                  ForceApplyInfo &info) {
-    meshi_physx_apply_force_to_rigid_body(m_phys, rigidBody, info);
+    detail::api().meshi_physx_apply_force_to_rigid_body(m_phys, rigidBody, info);
   }
 
   auto
   get_rigid_body_status(Handle<RigidBody> &rigidBody) -> PhysicsActorStatus & {
-    return meshi_physx_get_rigid_body_status(m_phys, rigidBody);
+    return detail::api().meshi_physx_get_rigid_body_status(m_phys, rigidBody);
   }
 
 private:


### PR DESCRIPTION
## Summary
- call `load_meshi_api` once in `EngineBackend` and route all C API usage through `MeshiApi`
- update graphics and physics systems to use loaded function pointers

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: meshi/bits/meshi_c_api.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fce40ea54832a8560bdf698085bf1