### PR TITLE
Use new meshi headers

### DIFF
--- a/src/api/meshi/backend.hpp
+++ b/src/api/meshi/backend.hpp
@@ -4,7 +4,8 @@
 #include <functional>
 #include <glm/glm.hpp>
 #include <memory>
-#include <meshi/bits/meshi_c_api.h>
+#include <meshi/meshi.h>
+#include "meshi/types.hpp"
 #include <meshi/bits/meshi_loader.hpp>
 #include <meshi/graphics.hpp>
 #include <meshi/physics.hpp>
@@ -17,25 +18,25 @@ public:
   explicit EngineBackend(const EngineBackendInfo &info) {
     static std::once_flag flag;
     std::call_once(flag, [&]() {
-      auto result = detail::load_meshi_api(info.application_root);
+      auto result = detail::load_meshi_api(info.application_location);
       if (result.is_err()) {
         throw std::runtime_error(result.err());
       }
     });
 
     auto &api = detail::api();
-    engine_ = api.meshi_make_engine(info);
+    engine_ = api.meshi_make_engine(&info);
 
     auto raw_phys = api.meshi_get_physics_system(engine_);
     auto raw_gfx = api.meshi_get_graphics_system(engine_);
-    m_phys = PhysicsSystem(raw_phys, raw_gfx);
+    m_phys = PhysicsSystem(raw_phys);
     m_gfx = GraphicsSystem(raw_gfx);
   }
 
   ~EngineBackend() = default;
 
   void register_event_callback(void *user_data,
-                               void (*callback)(meshi::Event &, void *)) {
+                               void (*callback)(MeshiEvent *, void *)) {
     detail::api().meshi_register_event_callback(engine_, user_data, callback);
   }
 

--- a/src/api/meshi/bits/components/physics_component.hpp
+++ b/src/api/meshi/bits/components/physics_component.hpp
@@ -2,6 +2,8 @@
 #include "meshi/bits/components/renderable_component.hpp"
 #include "meshi/engine.hpp"
 #include <meshi/bits/util/slice.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtx/quaternion.hpp>
 namespace meshi {
 class PhysicsComponent : public ActorComponent {
 public:
@@ -33,11 +35,10 @@ public:
     if (root) {
       auto c = root->as_type<ActorComponent>();
       if (c) {
-        c->set_transform(engine()
-                             ->backend()
-                             .physics()
-                             .get_rigid_body_status(m_handle)
-                             .transform);
+        auto status = engine()->backend().physics().get_rigid_body_status(m_handle);
+        auto mat = glm::translate(glm::mat4(1.0f), status.position) *
+                   glm::toMat4(status.rotation);
+        c->set_transform(mat);
       }
     }
   }

--- a/src/api/meshi/bits/event.hpp
+++ b/src/api/meshi/bits/event.hpp
@@ -220,11 +220,34 @@ public:
 
   // Constructor to initialize the event handler with the Meshi engine
   explicit EventHandler(EngineBackend *engine) : engine_(engine) {
-    // Register the global callback function to the engine
     engine->register_event_callback(
-        this, // Pass the instance as user_data
-        [](Event &event, void *user_data) {
-          static_cast<EventHandler *>(user_data)->process_event(event);
+        this,
+        [](MeshiEvent *ev, void *user_data) {
+          Event e{};
+          e.type = static_cast<EventType>(ev->event_type);
+          e.source = static_cast<EventSource>(ev->source);
+          e.timestamp = ev->timestamp;
+          switch (e.type) {
+          case EventType::Pressed:
+          case EventType::Released:
+            e.payload.press.key = static_cast<KeyCode>(ev->payload.press.key);
+            e.payload.press.previous =
+                static_cast<EventType>(ev->payload.press.previous);
+            break;
+          case EventType::Motion2D:
+            e.payload.motion2d.motion =
+                {ev->payload.motion2d.motion.x, ev->payload.motion2d.motion.y};
+            break;
+          default:
+            break;
+          }
+          if (e.source == EventSource::MouseButton) {
+            e.payload.mouse_button.button =
+                static_cast<MouseButton>(ev->payload.mouse_button.button);
+            e.payload.mouse_button.position =
+                {ev->payload.mouse_button.pos.x, ev->payload.mouse_button.pos.y};
+          }
+          static_cast<EventHandler *>(user_data)->process_event(e);
         });
   }
 

--- a/src/api/meshi/bits/meshi_loader.hpp
+++ b/src/api/meshi/bits/meshi_loader.hpp
@@ -11,40 +11,40 @@ namespace detail {
 
 struct MeshiApi {
     // Engine
-    decltype(&meshi_make_engine) meshi_make_engine{};
-    decltype(&meshi_make_engine_headless) meshi_make_engine_headless{};
-    decltype(&meshi_destroy_engine) meshi_destroy_engine{};
-    decltype(&meshi_register_event_callback) meshi_register_event_callback{};
-    decltype(&meshi_update) meshi_update{};
-    decltype(&meshi_get_graphics_system) meshi_get_graphics_system{};
+    decltype(&::meshi_make_engine) meshi_make_engine{};
+    decltype(&::meshi_make_engine_headless) meshi_make_engine_headless{};
+    decltype(&::meshi_destroy_engine) meshi_destroy_engine{};
+    decltype(&::meshi_register_event_callback) meshi_register_event_callback{};
+    decltype(&::meshi_update) meshi_update{};
+    decltype(&::meshi_get_graphics_system) meshi_get_graphics_system{};
 
     // Graphics
-    decltype(&meshi_gfx_create_renderable) meshi_gfx_create_renderable{};
-    decltype(&meshi_gfx_create_cube) meshi_gfx_create_cube{};
-    decltype(&meshi_gfx_create_sphere) meshi_gfx_create_sphere{};
-    decltype(&meshi_gfx_create_triangle) meshi_gfx_create_triangle{};
-    decltype(&meshi_gfx_set_renderable_transform) meshi_gfx_set_renderable_transform{};
-    decltype(&meshi_gfx_create_directional_light) meshi_gfx_create_directional_light{};
-    decltype(&meshi_gfx_set_directional_light_transform) meshi_gfx_set_directional_light_transform{};
-    decltype(&meshi_gfx_set_directional_light_info) meshi_gfx_set_directional_light_info{};
-    decltype(&meshi_gfx_set_camera) meshi_gfx_set_camera{};
-    decltype(&meshi_gfx_set_projection) meshi_gfx_set_projection{};
-    decltype(&meshi_gfx_capture_mouse) meshi_gfx_capture_mouse{};
+    decltype(&::meshi_gfx_create_renderable) meshi_gfx_create_renderable{};
+    decltype(&::meshi_gfx_create_cube) meshi_gfx_create_cube{};
+    decltype(&::meshi_gfx_create_sphere) meshi_gfx_create_sphere{};
+    decltype(&::meshi_gfx_create_triangle) meshi_gfx_create_triangle{};
+    decltype(&::meshi_gfx_set_renderable_transform) meshi_gfx_set_renderable_transform{};
+    decltype(&::meshi_gfx_create_directional_light) meshi_gfx_create_directional_light{};
+    decltype(&::meshi_gfx_set_directional_light_transform) meshi_gfx_set_directional_light_transform{};
+    decltype(&::meshi_gfx_set_directional_light_info) meshi_gfx_set_directional_light_info{};
+    decltype(&::meshi_gfx_set_camera) meshi_gfx_set_camera{};
+    decltype(&::meshi_gfx_set_projection) meshi_gfx_set_projection{};
+    decltype(&::meshi_gfx_capture_mouse) meshi_gfx_capture_mouse{};
 
     // Physics
-    decltype(&meshi_get_physics_system) meshi_get_physics_system{};
-    decltype(&meshi_physx_set_gravity) meshi_physx_set_gravity{};
-    decltype(&meshi_physx_create_material) meshi_physx_create_material{};
-    decltype(&meshi_physx_release_material) meshi_physx_release_material{};
-    decltype(&meshi_physx_create_rigid_body) meshi_physx_create_rigid_body{};
-    decltype(&meshi_physx_release_rigid_body) meshi_physx_release_rigid_body{};
-    decltype(&meshi_physx_apply_force_to_rigid_body) meshi_physx_apply_force_to_rigid_body{};
-    decltype(&meshi_physx_set_rigid_body_transform) meshi_physx_set_rigid_body_transform{};
-    decltype(&meshi_physx_get_rigid_body_status) meshi_physx_get_rigid_body_status{};
-    decltype(&meshi_physx_set_collision_shape) meshi_physx_set_collision_shape{};
-    decltype(&meshi_physx_get_contacts) meshi_physx_get_contacts{};
-    decltype(&meshi_physx_collision_shape_sphere) meshi_physx_collision_shape_sphere{};
-    decltype(&meshi_physx_collision_shape_box) meshi_physx_collision_shape_box{};
+    decltype(&::meshi_get_physics_system) meshi_get_physics_system{};
+    decltype(&::meshi_physx_set_gravity) meshi_physx_set_gravity{};
+    decltype(&::meshi_physx_create_material) meshi_physx_create_material{};
+    decltype(&::meshi_physx_release_material) meshi_physx_release_material{};
+    decltype(&::meshi_physx_create_rigid_body) meshi_physx_create_rigid_body{};
+    decltype(&::meshi_physx_release_rigid_body) meshi_physx_release_rigid_body{};
+    decltype(&::meshi_physx_apply_force_to_rigid_body) meshi_physx_apply_force_to_rigid_body{};
+    decltype(&::meshi_physx_set_rigid_body_transform) meshi_physx_set_rigid_body_transform{};
+    decltype(&::meshi_physx_get_rigid_body_status) meshi_physx_get_rigid_body_status{};
+    decltype(&::meshi_physx_set_collision_shape) meshi_physx_set_collision_shape{};
+    decltype(&::meshi_physx_get_contacts) meshi_physx_get_contacts{};
+    decltype(&::meshi_physx_collision_shape_sphere) meshi_physx_collision_shape_sphere{};
+    decltype(&::meshi_physx_collision_shape_box) meshi_physx_collision_shape_box{};
 };
 
 auto load_meshi_api(const std::filesystem::path& lib_path)

--- a/src/api/meshi/engine.hpp
+++ b/src/api/meshi/engine.hpp
@@ -21,7 +21,8 @@ public:
   static auto make(EngineInfo info) -> Result<Engine, Error> {
     const auto backend_info = EngineBackendInfo{
         .application_name = info.application_name.c_str(),
-        .application_root = info.application_root.c_str(),
+        .application_location = info.application_root.c_str(),
+        .headless = 0,
     };
 
     return make_result<Engine, Error>(Engine(backend_info));

--- a/src/api/meshi/types.hpp
+++ b/src/api/meshi/types.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <meshi/meshi_types.h>
+#include <glm/glm.hpp>
+
+namespace meshi {
+
+using EngineBackendInfo = MeshiEngineInfo;
+using RawEngineBackend = MeshiEngine;
+using RawGraphicsSystem = MeshiRenderEngine;
+using RawPhysicsSystem = MeshiPhysicsSimulation;
+
+template <typename T> using Handle = MeshiHandle;
+
+namespace gfx {
+using Renderable = MeshiMeshObject;
+struct RenderableCreateInfo {
+  const char *mesh = "";
+  const char *material = "";
+  glm::mat4 transform = glm::mat4(1.0f);
+};
+using DirectionalLight = MeshiDirectionalLight;
+struct DirectionalLightInfo {
+  glm::vec4 direction{0.0f};
+  glm::vec4 color{1.0f};
+  float intensity = 1.0f;
+};
+} // namespace gfx
+
+using PhysicsMaterial = MeshiMaterial;
+using PhysicsMaterialCreateInfo = MeshiMaterialInfo;
+using RigidBody = MeshiRigidBody;
+struct RigidBodyCreateInfo {
+  Handle<PhysicsMaterial> material{};
+  glm::vec3 initial_position{0.0f};
+  glm::vec3 initial_velocity{0.0f};
+  glm::quat initial_rotation{1.0f, 0.0f, 0.0f, 0.0f};
+  std::uint32_t has_gravity{0};
+};
+using ForceApplyInfo = MeshiForceApplyInfo;
+struct PhysicsActorStatus {
+  glm::vec3 position{0.0f};
+  glm::quat rotation{1.0f, 0.0f, 0.0f, 0.0f};
+};
+
+} // namespace meshi
+


### PR DESCRIPTION
## Summary
- add compatibility aliases bridging project types to `meshi.h` and `meshi_types.h`
- convert graphics and physics wrappers to marshal GLM types into the new Meshi C API
- adapt event and backend handling to use `MeshiEvent` callbacks and physics status outputs

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689037c3c220832a9408bfcb403844f8