### PR TITLE
fix: correct physics component include

### DIFF
--- a/src/api/meshi/bits/components/physics_component.hpp
+++ b/src/api/meshi/bits/components/physics_component.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "meshi/bits/components/renderable_component.hpp"
+#include "meshi/bits/components/actor_component.hpp"
 #include "meshi/engine.hpp"
 #include <meshi/bits/util/slice.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
## Summary
- include `actor_component.hpp` in `PhysicsComponent` instead of `renderable_component.hpp`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: No rule to make target 'meshi-rs/libmeshi.so')*


------
https://chatgpt.com/codex/tasks/task_e_689180b6e2d0832abea81657249a92b5