### PR TITLE
Include GLM transform and inverse headers

### DIFF
--- a/src/api/meshi/bits/components/camera_component.hpp
+++ b/src/api/meshi/bits/components/camera_component.hpp
@@ -2,6 +2,8 @@
 #define GLM_FORCE_LEFT_HANDED
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include "glm/ext/matrix_clip_space.hpp"
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/matrix_inverse.hpp>
 #include <meshi/bits/components/actor_component.hpp>
 namespace meshi { 
 class CameraComponent;


### PR DESCRIPTION
## Summary
- include GLM `matrix_transform` and `matrix_inverse` headers in `CameraComponent`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: No rule to make target 'meshi-rs/libmeshi.so')*


------
https://chatgpt.com/codex/tasks/task_e_689180be0d04832aa67de10bf57f7bd4