### PR TITLE
Use dynamic_cast for type check

### DIFF
--- a/src/api/meshi/bits/objects/base.hpp
+++ b/src/api/meshi/bits/objects/base.hpp
@@ -8,7 +8,7 @@
 namespace meshi {
 class Component;
 
-// Basis of all Objects. 
+// Basis of all Objects.
 // Can contain sub-objects.
 // Can be activated/deactivated.
 class Object {
@@ -52,7 +52,7 @@ public:
   }
 
   template <typename T> inline auto is_type() -> bool {
-    return (std::dynamic_pointer_cast<T>(this));
+    return dynamic_cast<T *>(this) != nullptr;
   }
 
   // Provides filtered vector of all subobjects of that type


### PR DESCRIPTION
## Summary
- Replace `std::dynamic_pointer_cast` with `dynamic_cast` for runtime type checks

## Testing
- `cmake -S . -B build` *(fails: missing meshi-rs/libmeshi.so)*

------
https://chatgpt.com/codex/tasks/task_e_689180c1db80832a9a8b13b193f8d79b