### PR TITLE
Fix missing unordered_map include in Actor

### DIFF
--- a/src/api/meshi/bits/objects/actor.hpp
+++ b/src/api/meshi/bits/objects/actor.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <unordered_map>
 #include <meshi/bits/objects/base.hpp>
 #include <meshi/bits/components/actor_component.hpp>
 namespace meshi {


### PR DESCRIPTION
## Summary
- include `<unordered_map>` in `actor.hpp` so the header compiles where `std::unordered_map` is used

## Testing
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: No rule to make target 'meshi-rs/libmeshi.so')*

------
https://chatgpt.com/codex/tasks/task_e_689180c4e24c832ab8b5d579389fdbb7