### PR TITLE
Remove stray semicolon in ActorComponent member list

### DIFF
--- a/src/api/meshi/bits/components/actor_component.hpp
+++ b/src/api/meshi/bits/components/actor_component.hpp
@@ -41,7 +41,6 @@ public:
 private:
   friend class Actor;
   glm::mat4 m_transform = glm::mat4(1.0);
-  ;
   glm::vec3 m_front = {0.0, 0.0, 1.0};
   glm::vec3 m_right = {1.0, 0.0, 0.0};
   glm::vec3 m_up = {0.0, 1.0, 0.0};


### PR DESCRIPTION
## Summary
- Drop extraneous semicolon after `m_transform` member in `ActorComponent`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: No rule to make target 'meshi-rs/libmeshi.so')*


------
https://chatgpt.com/codex/tasks/task_e_689180c64e74832a9c883aded3a7bc5a