### PR TITLE
Include iterator for Component base

### DIFF
--- a/src/api/meshi/bits/components/base.hpp
+++ b/src/api/meshi/bits/components/base.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "meshi/bits/objects/base.hpp"
 #include <algorithm>
+#include <iterator>
 #include <glm/glm.hpp>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Summary
- include `<iterator>` in component base header so `std::begin` and `std::end` resolve

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: No rule to make target `meshi-rs/libmeshi.so`)*

------
https://chatgpt.com/codex/tasks/task_e_689180c87c90832a8de768815a8328b1